### PR TITLE
Fix token regeneration mail message

### DIFF
--- a/scripts/regenerate_token.py
+++ b/scripts/regenerate_token.py
@@ -38,10 +38,10 @@ with open(TOKENS_FILE, 'w') as f:
 # Send email notification
 url = f"http://<your-node>:8082/download?token={token}"
 subject = "🔁 HI-pfs Token Renewed"
-message = f"Your download token has expired and was renewed.
+message = f"""Your download token has expired and was renewed.
 
- File: {zip_filename}
- Link: {url}"
+File: {zip_filename}
+Link: {url}"""
 
 os.system(f'echo "{message}" | mail -s "{subject}" "{email}"')
 


### PR DESCRIPTION
## Summary
- format regeneration email properly with triple-quoted f-string

## Testing
- `python3 -m py_compile scripts/regenerate_token.py`


------
https://chatgpt.com/codex/tasks/task_e_6874eec34cc0832a9db5926c0b16e622