### PR TITLE
Add sanitize_token tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,18 @@ ssh <USERNAME>@<SUBDOMAIN>
 python3 ~/token-server/generate_token.py ~/ipfs-admin/uploads/<LOCALFOLDER>
 ```
 - you will then receive the token, the name of zipped folder and the download link by email
-- Once the zip downloaded, the access token will be revoked and a new one will be genrated and sent again by email. 
+- Once the zip downloaded, the access token will be revoked and a new one will be genrated and sent again by email.
+
+## Running Tests
+
+To execute the unit tests locally:
+
+```bash
+pip install pytest
+pytest
+```
+
+This will run all tests under the `tests/` directory.
 
 ⸻
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,40 @@
+import importlib
+import os
+import sys
+import types
+
+# Ensure the project root is on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Create a minimal Flask stub so that scripts.server can be imported without Flask installed
+flask_stub = types.ModuleType('flask')
+
+class DummyFlask:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def route(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+flask_stub.Flask = DummyFlask
+flask_stub.request = types.SimpleNamespace(remote_addr='127.0.0.1')
+flask_stub.send_file = lambda *a, **kw: None
+flask_stub.abort = lambda *a, **kw: None
+sys.modules.setdefault('flask', flask_stub)
+
+server = importlib.import_module('scripts.server')
+
+
+def test_valid_token_returns_match():
+    token = 'ValidToken_123-abc'
+    assert server.sanitize_token(token) is not None
+
+
+def test_invalid_token_space_returns_none():
+    assert server.sanitize_token('invalid token') is None
+
+
+def test_invalid_token_special_char_returns_none():
+    assert server.sanitize_token('invalid$token') is None


### PR DESCRIPTION
## Summary
- add pytest coverage for `scripts.server.sanitize_token`
- document how to run tests with pytest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874f4b93154832aa3419f0baecd0696