### PR TITLE
Limit Pylint checks to Python files

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,10 @@
 name: Pylint
 
-on: [push]
+on:
+  push:
+    paths:
+      - '**/*.py'
+      - '.github/workflows/pylint.yml'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- only trigger the Pylint workflow when Python files change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874f6873100832ab81a4ce0fa7f16f6