### PR TITLE
Improve token server robustness

### DIFF
--- a/scripts/generate_token.py
+++ b/scripts/generate_token.py
@@ -11,6 +11,20 @@ TOKENS_FILE = os.path.join(BASE_DIR, 'tokens', 'tokens.json')
 ZIPS_DIR = os.path.join(BASE_DIR, 'zips')
 LOG_FILE = os.path.join(BASE_DIR, 'logs', 'access.log')
 
+def load_tokens():
+    if not os.path.exists(TOKENS_FILE):
+        return {}
+    try:
+        with open(TOKENS_FILE, 'r') as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+def save_tokens(tokens):
+    os.makedirs(os.path.dirname(TOKENS_FILE), exist_ok=True)
+    with open(TOKENS_FILE, 'w') as f:
+        json.dump(tokens, f, indent=2)
+
 if len(sys.argv) < 2:
     print("Usage: python3 generate_token.py <folder>")
     sys.exit(1)
@@ -39,14 +53,10 @@ with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
 
 # Load or create token registry
 os.makedirs(os.path.dirname(TOKENS_FILE), exist_ok=True)
-tokens = {}
-if os.path.exists(TOKENS_FILE):
-    with open(TOKENS_FILE, 'r') as f:
-        tokens = json.load(f)
+tokens = load_tokens()
 
 tokens[token] = zip_filename
-with open(TOKENS_FILE, 'w') as f:
-    json.dump(tokens, f, indent=2)
+save_tokens(tokens)
 
 # Log generation
 token_log_line = f"[{timestamp}] Generated token={token} for file={zip_filename}\n"

--- a/scripts/regenerate_token.py
+++ b/scripts/regenerate_token.py
@@ -9,6 +9,20 @@ BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 TOKENS_FILE = os.path.join(BASE_DIR, 'tokens', 'tokens.json')
 ZIPS_DIR = os.path.join(BASE_DIR, 'zips')
 
+def load_tokens():
+    if not os.path.exists(TOKENS_FILE):
+        return {}
+    try:
+        with open(TOKENS_FILE, 'r') as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+def save_tokens(tokens):
+    os.makedirs(os.path.dirname(TOKENS_FILE), exist_ok=True)
+    with open(TOKENS_FILE, 'w') as f:
+        json.dump(tokens, f, indent=2)
+
 # Expect two arguments: the ZIP filename and the destination email address
 if len(sys.argv) < 3:
     print("Usage: regenerate_token.py <zip_filename> <email>")
@@ -27,14 +41,10 @@ token = secrets.token_urlsafe(16)
 
 # Load or create token registry
 os.makedirs(os.path.dirname(TOKENS_FILE), exist_ok=True)
-tokens = {}
-if os.path.exists(TOKENS_FILE):
-    with open(TOKENS_FILE, 'r') as f:
-        tokens = json.load(f)
+tokens = load_tokens()
 
 tokens[token] = zip_filename
-with open(TOKENS_FILE, 'w') as f:
-    json.dump(tokens, f, indent=2)
+save_tokens(tokens)
 
 # Send email notification
 url = f"http://<your-node>:8082/download?token={token}"

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -32,17 +32,35 @@ def log_event(message):
 def sanitize_token(token):
     return re.fullmatch(r"[A-Za-z0-9_\-]+", token)
 
+def is_safe_path(directory, path):
+    """Ensure the requested path is contained within the directory."""
+    abs_directory = os.path.realpath(directory)
+    abs_path = os.path.realpath(path)
+    return os.path.commonpath([abs_path, abs_directory]) == abs_directory
+
+def load_tokens():
+    """Load the token registry, returning an empty dict if missing or corrupt."""
+    if not os.path.exists(TOKENS_FILE):
+        return {}
+    try:
+        with open(TOKENS_FILE, 'r') as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        log_event(f"ERROR reading tokens file: {e}")
+        return {}
+
+def save_tokens(tokens):
+    os.makedirs(os.path.dirname(TOKENS_FILE), exist_ok=True)
+    with open(TOKENS_FILE, 'w') as f:
+        json.dump(tokens, f, indent=2)
+
 @app.route('/download', methods=['GET'])
 def download():
     token = request.args.get('token')
     if not token or not sanitize_token(token):
         abort(400, description="Invalid or missing token.")
 
-    if not os.path.exists(TOKENS_FILE):
-        abort(500, description="Token registry missing.")
-
-    with open(TOKENS_FILE, 'r') as f:
-        tokens = json.load(f)
+    tokens = load_tokens()
 
     if token not in tokens:
         log_event(f"REJECTED invalid token: {token}")
@@ -50,6 +68,10 @@ def download():
 
     filename = tokens[token]
     zip_path = os.path.join(ZIPS_DIR, filename)
+
+    if not is_safe_path(ZIPS_DIR, zip_path):
+        log_event(f"REJECTED unsafe path: {zip_path}")
+        abort(400, description="Invalid file path.")
 
     if not os.path.isfile(zip_path):
         log_event(f"ERROR missing ZIP: {filename}")
@@ -59,8 +81,7 @@ def download():
 
     # Invalidate token
     del tokens[token]
-    with open(TOKENS_FILE, 'w') as f:
-        json.dump(tokens, f, indent=2)
+    save_tokens(tokens)
 
     # Regenerate token and send email
     EMAIL = get_email()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,3 +38,21 @@ def test_invalid_token_space_returns_none():
 
 def test_invalid_token_special_char_returns_none():
     assert server.sanitize_token('invalid$token') is None
+
+
+def test_is_safe_path_accepts_inside(tmp_path):
+    base = tmp_path
+    file_path = base / 'file.txt'
+    file_path.write_text('data')
+    assert server.is_safe_path(str(base), str(file_path))
+
+
+def test_is_safe_path_rejects_outside(tmp_path):
+    base = tmp_path
+    outside = tmp_path / '..' / 'evil.txt'
+    assert not server.is_safe_path(str(base), str(outside.resolve()))
+
+
+def test_load_tokens_missing_returns_empty_dict(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, 'TOKENS_FILE', str(tmp_path / 'missing.json'))
+    assert server.load_tokens() == {}


### PR DESCRIPTION
## Summary
- add validation helpers to server
- refactor token generation scripts to use helper functions
- test download helper logic with new unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687507d22d74832ab41744d6e5fb5aaa