### PR TITLE
Check for ipfs desktop before setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ HI-pfs is a robust, scalable, and self-maintaining network of IPFS nodes deploye
       - An existing web domain that you own.
       - A Cloudflare account (can be created later in the process).
       - IPFS Desktop app installed (easier for node-wise maintenance): [linux amd64 version](https://github.com/ipfs/ipfs-desktop/releases/latest)
+        The `setup.sh` script requires the `ipfs-desktop` command and will abort if it's not detected.
    - A stable internet connection, **LAN** or **WAN**
 
 ### 1. Flash and Boot Raspberry Pi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,6 +31,16 @@ echo "🌍 Detected setup version: $SETUP_VERSION"
 ### 2. PREREQUISITES
 prerequisites() {
   echo "[0/6] Installing prerequisites..."
+
+  # Ensure the IPFS Desktop application is present
+  if ! command -v ipfs-desktop &>/dev/null; then
+    echo "❌ IPFS Desktop not detected."
+    echo "Please install it first: https://github.com/ipfs/ipfs-desktop/releases/latest"
+    exit 1
+  else
+    echo "✓ IPFS Desktop detected"
+  fi
+
   sudo apt update
   sudo apt install -y curl unzip python3 python3-pip zip cron mailutils inotify-tools lsb-release
 


### PR DESCRIPTION
## Summary
- make setup.sh exit if `ipfs-desktop` isn't installed
- document that `setup.sh` requires `ipfs-desktop`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877aa74dea0832a831bd572cd0c3a4f