### PR TITLE
Fix pip install on Debian with PEP 668

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -68,7 +68,8 @@ prerequisites() {
     sudo apt install -y chromium-browser
   fi
 
-  pip3 install flask flask-mail requests
+  # Handle Debian's PEP 668 "externally-managed" environment
+  pip3 install --break-system-packages flask flask-mail requests
 }
 
 


### PR DESCRIPTION
## Summary
- update setup script to handle Debian's externally managed Python environment by passing `--break-system-packages`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877b9beafe4832abcb9582c1c069706