### PR TITLE
Add Kubo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,18 @@ HI-pfs is a robust, scalable, and self-maintaining network of IPFS nodes deploye
       - **Raspberry Pi OS 64 Lite or Desktop (easier)**. You can use Rapberry Pi Imager for that. There is a copy of the tested version you can use to replicate if you want.
       - An existing web domain that you own.
       - A Cloudflare account (can be created later in the process).
-      - IPFS Desktop app installed (easier for node-wise maintenance): [linux amd64 version](https://github.com/ipfs/ipfs-desktop/releases/latest)
-        The `setup.sh` script requires the `ipfs-desktop` command and will abort if it's not detected.
+     - **Kubo (IPFS CLI)** installed. Download the Linux binary from [dist.ipfs.tech](https://dist.ipfs.tech/):
+       ```bash
+       wget https://dist.ipfs.tech/kubo/v0.36.0/kubo_v0.36.0_linux-amd64.tar.gz
+       tar -xvzf kubo_v0.36.0_linux-amd64.tar.gz
+       cd kubo
+       sudo bash install.sh
+       ```
+       Test the installation:
+       ```bash
+       ipfs --version
+       ```
+       You should see `ipfs version 0.36.0`. The `setup.sh` script requires the `ipfs` command and will abort if it's not detected.
    - A stable internet connection, **LAN** or **WAN**
 
 ### 1. Flash and Boot Raspberry Pi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -32,37 +32,18 @@ echo "🌍 Detected setup version: $SETUP_VERSION"
 prerequisites() {
   echo "[0/6] Installing prerequisites..."
 
-  # Ensure the IPFS Desktop application is present
-  if ! command -v ipfs-desktop &>/dev/null; then
-    echo "❌ IPFS Desktop not detected."
-    echo "Please install it first: https://github.com/ipfs/ipfs-desktop/releases/latest"
+  # Ensure Kubo (ipfs CLI) is installed beforehand
+  if ! command -v ipfs &>/dev/null; then
+    echo "❌ Kubo (ipfs) not detected."
+    echo "Please install it first: https://dist.ipfs.tech/kubo/"
     exit 1
   else
-    echo "✓ IPFS Desktop detected"
+    echo "✓ Kubo detected: $(ipfs version)"
   fi
 
   sudo apt update
   sudo apt install -y curl unzip python3 python3-pip zip cron mailutils inotify-tools lsb-release
 
-  if ! command -v ipfs &>/dev/null; then
-    echo "→ IPFS not found, installing..."
-    if ! curl -fsSL https://dist.ipfs.tech/go-ipfs/install.sh -o /tmp/ipfs-install.sh; then
-      echo "❌ Failed to download IPFS installer." >&2
-      exit 1
-    fi
-    if ! sudo bash /tmp/ipfs-install.sh; then
-      echo "❌ IPFS install failed. Aborting." >&2
-      exit 1
-    fi
-    rm -f /tmp/ipfs-install.sh
-  else
-    echo "✓ IPFS already installed: $(ipfs version)"
-  fi
-
-  if ! command -v ipfs &>/dev/null; then
-    echo "❌ IPFS install failed. Aborting." >&2
-    exit 1
-  fi
 
   if ! command -v caddy &>/dev/null; then
     echo "→ Installing Caddy (HTTPS reverse proxy)..."


### PR DESCRIPTION
## Summary
- document Kubo CLI pre-install instructions
- check for Kubo instead of IPFS Desktop in setup prerequisites

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877baaf34fc832a9036ffc229bad8b9