### PR TITLE
Fix Kubo install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ account:
       - **Raspberry Pi OS 64 Lite or Desktop (easier)**. You can use Rapberry Pi Imager for that. There is a copy of the tested version you can use to replicate if you want.
       - An existing web domain that you own.
       - A Cloudflare account (can be created later in the process).
-     - **Kubo (IPFS CLI)**. The setup will automatically download and install the latest release from [dist.ipfs.tech](https://dist.ipfs.tech/) if the `ipfs` command is missing. `self-maintenance.sh` also keeps Kubo up to date.
+     - **Kubo (IPFS CLI)** version **0.36.0** is currently used. The setup downloads this release from [dist.ipfs.tech](https://dist.ipfs.tech/kubo/v0.36.0/kubo_v0.36.0_linux-arm64.tar.gz). Check [dist.ipfs.tech](https://dist.ipfs.tech/) for newer versions and either update this URL and send a pull request or run `self-maintenance.sh` after installation to upgrade.
    - A stable internet connection, **LAN** or **WAN**
 
 ### 1. Flash and Boot Raspberry Pi

--- a/scripts/self-maintenance.sh
+++ b/scripts/self-maintenance.sh
@@ -32,7 +32,11 @@ LATEST=$(curl -s https://dist.ipfs.tech/kubo/versions | grep -o 'v[0-9.]*' | hea
 
 if [[ "$LATEST" != "$INSTALLED" ]]; then
   echo "→ Installing Kubo $LATEST" >> "$LOGFILE"
-  curl -s https://dist.ipfs.tech/kubo/install.sh | sudo bash >> "$LOGFILE" 2>&1
+  KUBO_URL="https://dist.ipfs.tech/kubo/${LATEST}/kubo_${LATEST}_linux-arm64.tar.gz"
+  curl -L "$KUBO_URL" -o /tmp/kubo.tar.gz >> "$LOGFILE" 2>&1
+  tar -xzf /tmp/kubo.tar.gz -C /tmp >> "$LOGFILE" 2>&1
+  sudo bash /tmp/kubo/install.sh >> "$LOGFILE" 2>&1
+  rm -rf /tmp/kubo /tmp/kubo.tar.gz
   NEED_REBOOT=1
 else
   echo "→ Kubo is already up to date ($INSTALLED)" >> "$LOGFILE"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -35,10 +35,19 @@ prerequisites() {
   # Ensure Kubo (ipfs CLI) is installed beforehand
   if ! command -v ipfs &>/dev/null; then
     echo "→ Kubo not found. Installing..."
-    if ! curl -fsSL https://dist.ipfs.tech/kubo/install.sh | sudo bash; then
-      echo "❌ Failed to install Kubo." >&2
+    KUBO_VERSION="v0.36.0"
+    KUBO_URL="https://dist.ipfs.tech/kubo/${KUBO_VERSION}/kubo_${KUBO_VERSION}_linux-arm64.tar.gz"
+    echo "ℹ️ Using Kubo ${KUBO_VERSION}. Check https://dist.ipfs.tech/kubo/ for newer releases."
+    curl -L "$KUBO_URL" -o /tmp/kubo.tar.gz || {
+      echo "❌ Failed to download Kubo." >&2
       exit 1
-    fi
+    }
+    tar -xzf /tmp/kubo.tar.gz -C /tmp
+    sudo bash /tmp/kubo/install.sh || {
+      echo "❌ Kubo install failed." >&2
+      exit 1
+    }
+    rm -rf /tmp/kubo /tmp/kubo.tar.gz
   fi
   echo "✓ Kubo detected: $(ipfs version)"
 
@@ -104,15 +113,19 @@ setup_ipfs_service() {
   # Check IPFS binary
   if ! command -v ipfs &>/dev/null; then
     echo "❌ IPFS command not found. Reinstalling..."
-    if ! curl -fsSL https://dist.ipfs.tech/kubo/install.sh -o /tmp/ipfs-install.sh; then
-      echo "❌ Failed to download Kubo installer." >&2
+    KUBO_VERSION="v0.36.0"
+    KUBO_URL="https://dist.ipfs.tech/kubo/${KUBO_VERSION}/kubo_${KUBO_VERSION}_linux-arm64.tar.gz"
+    echo "ℹ️ Using Kubo ${KUBO_VERSION}. Check https://dist.ipfs.tech/kubo/ for newer releases."
+    curl -L "$KUBO_URL" -o /tmp/kubo.tar.gz || {
+      echo "❌ Failed to download Kubo." >&2
       return 1
-    fi
-    if ! sudo bash /tmp/ipfs-install.sh; then
+    }
+    tar -xzf /tmp/kubo.tar.gz -C /tmp
+    if ! sudo bash /tmp/kubo/install.sh; then
       echo "❌ Kubo install failed." >&2
       return 1
     fi
-    rm -f /tmp/ipfs-install.sh
+    rm -rf /tmp/kubo /tmp/kubo.tar.gz
     if ! command -v ipfs &>/dev/null; then
       echo "❌ Kubo install failed." >&2
       return 1


### PR DESCRIPTION
## Summary
- download Kubo `v0.36.0` using the direct tarball URL
- install with that version in setup and self-maintenance
- mention the version in the README with instructions to check for updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a213602ac832a92655d2a0fe506a6