### PR TITLE
Add Raspberry Pi desktop launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,28 @@ This runs the unit tests found in the `tests/` directory.
 
 Continuous integration on GitHub also checks all Python files with `pylint`.
 
+## Desktop Launcher
+
+A small GUI can be used on Raspberry Pi OS to run the most common tasks.
+It fetches the latest scripts from GitHub each time, so the node can be
+managed even without cloning this repository.
+
+1. Copy `hi-pfs.desktop` to your desktop:
+
+   ```bash
+   cp hi-pfs.desktop ~/Desktop/
+   ```
+
+2. Edit the `Exec` path in the file so it matches the location of this
+   repository on your Pi.
+
+Launching the icon opens a window with three buttons that execute the
+same `curl` commands documented above:
+
+- **Install** – `bash <(curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/bootstrap.sh)`
+- **Diagnostics & Tests** – `bash <(curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/diagnostics.sh)`
+- **Delete** – `bash <(curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/init.sh)`
+
 ## Learn More
 
 Review each script in the `scripts/` folder to understand the setup process and

--- a/hi-pfs.desktop
+++ b/hi-pfs.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=HI-pfs Launcher
+Exec=python3 /home/pi/HI-pfs/scripts/gui_launcher.py
+Icon=utilities-terminal
+Terminal=false
+Categories=Utility;

--- a/scripts/gui_launcher.py
+++ b/scripts/gui_launcher.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Simple GUI launcher for HI-pfs scripts fetched from GitHub."""
+import subprocess
+import os
+import tkinter as tk
+from tkinter import messagebox
+
+TERMINAL = os.environ.get("TERMINAL", "x-terminal-emulator")
+
+INSTALL_CMD = (
+    "bash <(curl -fsSL "
+    "https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/bootstrap.sh)"
+)
+DIAG_CMD = (
+    "bash <(curl -fsSL "
+    "https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/diagnostics.sh)"
+)
+DELETE_CMD = (
+    "bash <(curl -fsSL "
+    "https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/init.sh)"
+)
+
+
+def run_command(cmd: str) -> None:
+    """Open a terminal and execute the provided command."""
+    try:
+        subprocess.Popen([TERMINAL, "-e", "bash", "-c", cmd])
+    except FileNotFoundError:
+        messagebox.showerror("Error", f"Terminal '{TERMINAL}' not found")
+
+
+root = tk.Tk()
+root.title("HI-pfs Launcher")
+root.resizable(False, False)
+
+btn_install = tk.Button(root, text="Install", width=20,
+                        command=lambda: run_command(INSTALL_CMD))
+btn_diag = tk.Button(root, text="Diagnostics & Tests", width=20,
+                     command=lambda: run_command(DIAG_CMD))
+btn_delete = tk.Button(root, text="Delete", width=20,
+                       command=lambda: run_command(DELETE_CMD))
+
+for btn in (btn_install, btn_diag, btn_delete):
+    btn.pack(pady=5)
+
+root.mainloop()


### PR DESCRIPTION
## Summary
- add a simple Tkinter GUI that runs install, diagnostic and delete scripts
- include a desktop entry pointing to the launcher
- document how to set up the launcher on Raspberry Pi
- run scripts directly from GitHub URLs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a3beeb5f0832ab79900e510da11ca