### PR TITLE
Add automatic autoremove after apt installs

### DIFF
--- a/scripts/self-maintenance.sh
+++ b/scripts/self-maintenance.sh
@@ -20,6 +20,7 @@ echo "[$TIMESTAMP] Self-maintenance started on $HOSTNAME" >> "$LOGFILE"
 # 1. System update
 echo "→ Updating system packages..." >> "$LOGFILE"
 sudo apt update -qq && sudo apt upgrade -y >> "$LOGFILE" 2>&1
+sudo apt autoremove -y >> "$LOGFILE" 2>&1
 
 # 2. Kubo upgrade
 echo "→ Checking Kubo version..." >> "$LOGFILE"
@@ -60,6 +61,7 @@ NEED_REBOOT=1
 # 4. Caddy upgrade
 echo "→ Updating Caddy..." >> "$LOGFILE"
 sudo apt install --only-upgrade -y caddy >> "$LOGFILE" 2>&1
+sudo apt autoremove -y >> "$LOGFILE" 2>&1
 
 # 5. Refresh token-server script
 SERVER_PY="/home/$USER/token-server/server.py"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -53,20 +53,25 @@ prerequisites() {
 
   sudo apt update
   sudo apt install -y curl unzip python3 python3-pip zip cron mailutils inotify-tools lsb-release parted exfat-fuse exfatprogs
+  # Remove any packages that are no longer required after installation
+  sudo apt autoremove -y
 
 
   if ! command -v caddy &>/dev/null; then
     echo "→ Installing Caddy (HTTPS reverse proxy)..."
     sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+    sudo apt autoremove -y
     curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
     curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
     sudo apt update
     sudo apt install -y caddy
+    sudo apt autoremove -y
   fi
 
   if ! command -v chromium-browser &>/dev/null; then
     echo "→ Installing Chromium for desktop WebUI..."
     sudo apt install -y chromium-browser
+    sudo apt autoremove -y
   fi
 
   # Handle Debian's PEP 668 "externally-managed" environment


### PR DESCRIPTION
## Summary
- clean up unneeded packages after installing deps in `setup.sh`
- run `apt autoremove` during self-maintenance to clear unused packages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a5ac4794c832aa65b7a383ef5b0a3