### PR TITLE
Fix permission bug in auto-token setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -249,7 +249,7 @@ setup_auto_token_generator() {
 
   mkdir -p "/home/$IPFS_USER/scripts" "/home/$IPFS_USER/ipfs-admin/uploads" "$(dirname $LOG_FILE)"
 
-  cat <<EOSH | sudo tee "$WATCH_SCRIPT" > /dev/null
+  cat <<EOSH | tee "$WATCH_SCRIPT" > /dev/null
 #!/bin/bash
 WATCH_DIR="/home/$IPFS_USER/ipfs-admin/uploads"
 LOG_FILE="$LOG_FILE"


### PR DESCRIPTION
## Summary
- fix permission denied error when creating auto_token_watch.sh

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e29429e74832a857b38a9a23df4af