### PR TITLE
Fix non-interactive bootstrap usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ These steps may vary depending on your domain provider:
 Run the script with sudo so it can create system services and token watcher:
 ```bash
 
-curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/bootstrap.sh | sudo bash
+sudo bash <(curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/bootstrap.sh)
 
 ```
 
@@ -150,14 +150,14 @@ All installer commands should be run with sudo or as root.
 2. (Optional) clean an existing install:
    ```bash
 
-   curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/init.sh | sudo bash
+   sudo bash <(curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/init.sh)
 
    ```
 3. Configure a Cloudflare tunnel and DNS for each node.
 4. Bootstrap a node:
    ```bash
 
-   curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/bootstrap.sh | sudo bash
+   sudo bash <(curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/bootstrap.sh)
 
    ```
    Follow the prompts for user, node name and tunnel information. Copy the
@@ -218,7 +218,7 @@ managed even without cloning this repository.
 Launching the icon opens a window with three buttons that execute the
 same `curl` commands documented above:
 
-- **Install** – `curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/bootstrap.sh | sudo bash`
+- **Install** – `sudo bash <(curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/bootstrap.sh)`
 - **Diagnostics & Tests** – `bash <(curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/diagnostics.sh)`
 - **Delete** – `bash <(curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/init.sh)`
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -6,6 +6,13 @@
 
 set -euo pipefail
 
+# Ensure we run interactively so prompts work
+if [[ ! -t 0 ]]; then
+  echo "This script must be run in an interactive shell."
+  echo "Use: sudo bash <(curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/bootstrap.sh)"
+  exit 1
+fi
+
 #-------------#
 # CONFIG
 #-------------#


### PR DESCRIPTION
## Summary
- warn if `bootstrap.sh` is run non-interactively
- document using process substitution in README for `bootstrap.sh` and `init.sh`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e40984938832ab97fedc6e530bcac