### PR TITLE
Fix bootstrap input check for piped installs

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,9 +8,16 @@ set -euo pipefail
 
 # Ensure we run interactively so prompts work
 if [[ ! -t 0 ]]; then
-  echo "This script must be run in an interactive shell."
-  echo "Use: sudo bash <(curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/bootstrap.sh)"
-  exit 1
+  # When piped into bash, stdin isn't a TTY. Attempt to reattach both stdin
+  # and stdout to /dev/tty so that prompts work correctly. If no terminal is
+  # available, abort with instructions for running interactively.
+  if [[ -e /dev/tty ]]; then
+    exec </dev/tty >/dev/tty 2>/dev/tty
+  else
+    echo "This script must be run in an interactive shell." >&2
+    echo "Use: curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/bootstrap.sh | sudo bash" >&2
+    exit 1
+  fi
 fi
 
 #-------------#


### PR DESCRIPTION
## Summary
- allow `bootstrap.sh` to read prompts from `/dev/tty`
- recommend pipe form in the error message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e45de1714832ab91846361797cf85